### PR TITLE
Use sha256 instead of md5 for hashing items

### DIFF
--- a/pytest_shard/pytest_shard.py
+++ b/pytest_shard/pytest_shard.py
@@ -36,15 +36,15 @@ def pytest_report_collectionfinish(config, items: Sequence[nodes.Node]) -> str:
     return msg
 
 
-def md5hash(x: str) -> int:
-    return int(hashlib.md5(x.encode()).hexdigest(), 16)
+def sha256hash(x: str) -> int:
+    return int.from_bytes(hashlib.sha256(x.encode()).digest(), "little")
 
 
 def filter_items_by_shard(
     items: Iterable[nodes.Node], shard_id: int, num_shards: int
 ) -> Sequence[nodes.Node]:
     """Computes `items` that should be tested in `shard_id` out of `num_shards` total shards."""
-    shards = [md5hash(item.nodeid) % num_shards for item in items]
+    shards = [sha256hash(item.nodeid) % num_shards for item in items]
 
     new_items = []
     for shard, item in zip(shards, items):

--- a/tests/test_pytest_shard.py
+++ b/tests/test_pytest_shard.py
@@ -32,7 +32,7 @@ def test_positive_int_with_non_num():
 
 
 @hypothesis.given(strategies.text())
-def test_sha2hash_deterministic(s):
+def test_sha256hash_deterministic(s):
     x = pytest_shard.sha256hash(s)
     y = pytest_shard.sha256hash(s)
     assert x == y

--- a/tests/test_pytest_shard.py
+++ b/tests/test_pytest_shard.py
@@ -32,17 +32,17 @@ def test_positive_int_with_non_num():
 
 
 @hypothesis.given(strategies.text())
-def test_md5hash_deterministic(s):
-    x = pytest_shard.md5hash(s)
-    y = pytest_shard.md5hash(s)
+def test_sha2hash_deterministic(s):
+    x = pytest_shard.sha256hash(s)
+    y = pytest_shard.sha256hash(s)
     assert x == y
     assert type(x) == int
 
 
 @hypothesis.given(strategies.text(), strategies.text())
-def test_md5hash_no_clash(s1, s2):
+def test_sha256hash_no_clash(s1, s2):
     if s1 != s2:
-        assert pytest_shard.md5hash(s1) != pytest_shard.md5hash(s2)
+        assert pytest_shard.sha256hash(s1) != pytest_shard.sha256hash(s2)
 
 
 MockItem = collections.namedtuple("MockItem", "nodeid")


### PR DESCRIPTION
I am personally incredibly sorry to be sending this PR.

pyca/cryptography is looking at using pytest-shard to speed up our tests (looks like it'll work great!). One of our CI jobs tests against OpenSSL in FIPS mode.

FIPS 140 is a cryptographic standard from the US Government, it's very bad, almost comedically so. One of the things it does is ban md5. This is because md5 is broken for most security purposes.

It is no doubt extremely obvious that md5 is not being used in a security sensitive way here. Nevertheless, OpenSSL in FIPS mode errors when you try to use it. So I've sent this PR, which simply swaps it for SHA256, which the FIPS gods allow.