### PR TITLE
Only log test names if more than one shard

### DIFF
--- a/pytest_shard/pytest_shard.py
+++ b/pytest_shard/pytest_shard.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser):
 def pytest_report_collectionfinish(config, items: Sequence[nodes.Node]) -> str:
     """Log how many and, if verbose, which items are tested in this shard."""
     msg = f"Running {len(items)} items in this shard"
-    if config.option.verbose > 0:
+    if config.option.verbose > 0 and config.getoption("num_shards") > 1:
         msg += ": " + ", ".join([item.nodeid for item in items])
     return msg
 


### PR DESCRIPTION
Thanks for the project. I have a small change that would improve my quality of life a lot :)

In general there is a lot of reasons to use verbose, especially locally and this ends up really spamming the output on larger projects I work with.