### PR TITLE
fix fstring in error message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   my-executor:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
     environment:
       NUM_CPUS: 2  # more CPUs visible but we're throttled to 2, which breaks auto-detec
 

--- a/pytest_shard/pytest_shard.py
+++ b/pytest_shard/pytest_shard.py
@@ -58,6 +58,6 @@ def pytest_collection_modifyitems(config, items: List[nodes.Node]):
     shard_id = config.getoption("shard_id")
     shard_total = config.getoption("num_shards")
     if shard_id >= shard_total:
-        raise ValueError("shard_num = f{shard_num} must be less than shard_total = f{shard_total}")
+        raise ValueError(f"{shard_id=} must be less than {shard_total=}")
 
     items[:] = filter_items_by_shard(items, shard_id, shard_total)


### PR DESCRIPTION
it was not a valid fstring so the error message just looked like this:
```
ValueError: shard_num = f{shard_num} must be less than shard_total = f{shard_total}
```